### PR TITLE
Remove custom processing of user mappings

### DIFF
--- a/src/main/java/com/julienphalip/ideavim/peekaboo/Peekaboo.java
+++ b/src/main/java/com/julienphalip/ideavim/peekaboo/Peekaboo.java
@@ -44,17 +44,6 @@ public class Peekaboo implements VimExtension {
         // Register mapping for quote character in normal mode
         List<KeyStroke> quoteKeyStroke = Collections.singletonList(KeyStroke.getKeyStroke('"'));
         KeyMapping normalModeKeyMapping = VimPlugin.getKey().getKeyMapping(MappingMode.NORMAL);
-        List<Pair<List<KeyStroke>, MappingInfo>> quoteMappings =
-                normalModeKeyMapping.getMapTo(quoteKeyStroke);
-        for (Pair<List<KeyStroke>, MappingInfo> mapping : quoteMappings) {
-            VimPlugin.getKey()
-                    .putKeyMapping(
-                            EnumSet.of(MappingMode.NORMAL),
-                            mapping.getSecond().getFromKeys(),
-                            getOwner(),
-                            new ShowRegistersHandler(quoteKeyStroke),
-                            false);
-        }
         if (normalModeKeyMapping.get(quoteKeyStroke) == null) {
             VimPlugin.getKey()
                     .putKeyMapping(
@@ -68,17 +57,6 @@ public class Peekaboo implements VimExtension {
         List<KeyStroke> controlRKeyStroke =
                 Collections.singletonList(KeyStroke.getKeyStroke("control R"));
         KeyMapping insertModeKeyMapping = VimPlugin.getKey().getKeyMapping(MappingMode.INSERT);
-        List<Pair<List<KeyStroke>, MappingInfo>> controlRMappings =
-                insertModeKeyMapping.getMapTo(controlRKeyStroke);
-        for (Pair<List<KeyStroke>, MappingInfo> mapping : controlRMappings) {
-            VimPlugin.getKey()
-                    .putKeyMapping(
-                            EnumSet.of(MappingMode.INSERT),
-                            mapping.getSecond().getFromKeys(),
-                            getOwner(),
-                            new ShowRegistersHandler(controlRKeyStroke),
-                            false);
-        }
         if (insertModeKeyMapping.get(controlRKeyStroke) == null) {
             VimPlugin.getKey()
                     .putKeyMapping(


### PR DESCRIPTION
User mappings should work in IdeaVim by default. However, with the current approach, there are two issues:
- It doesn't respect the `noremap` mappings (like `nnoremap A "`)
- If the user defines a mapping during runtime, it won't be processed by peekaboo plugin

We're planning to remove the `getMapTo` function from the API; however, it was used in the peekaboo plugin. I feel this functionality should work out of the box, and my testing confirms that.
This pull request removes the custom processing. Please let me know if I missed a case or if this doesn't work properly for you.

BTW, thank you for the great plugin!